### PR TITLE
Made some minor changes to utilise the IO String / String -> IO() implementation of commands

### DIFF
--- a/pgminer.hs
+++ b/pgminer.hs
@@ -9,11 +9,8 @@ import Tuura.Graph
 import Tuura.Log
 import Tuura.CmdLineFlags
 
-addId :: [String] -> [String]
-addId expressions =
-    return (unlines $ addIds expressions)
-  where
-    addIds = zipWith (\n s -> "p" ++ show n ++ " = " ++ s) [(1 :: Int)..]
+addIds :: [String] -> [String]
+addIds = zipWith (\n s -> "p" ++ show n ++ " = " ++ s) [(1 :: Int)..]
 
 toIntLog :: Log String -> (Log Int, Set Int, Int -> String)
 toIntLog log = (intLog, Set.map a2i alphabet, i2a)
@@ -37,7 +34,7 @@ main = do
                  Set.fromList [ (x, y) | x <- events, y <- events, x <= y ]
         co a b = cache Map.! (min a b, max a b)
         graphs = map (fmap decode) $ reduceLog co log 
-    let [expressions] = addId (map printGraphExpr graphs)
+    let expressions = unlines . addIds $ map printGraphExpr graphs
     if (optReport options) 
         then do
             let concurrenyReport = [ (decode x, decode y) | (x:xs) <- tails events, y <- xs, x `co` y ]

--- a/pgminer.hs
+++ b/pgminer.hs
@@ -8,12 +8,10 @@ import qualified Data.Map as Map
 import Tuura.Graph
 import Tuura.Log
 import Tuura.CmdLineFlags
-import System.FilePath
 
 addId :: [String] -> [String]
-addId expressions = do
-    let report = unlines $ addIds expressions
-    return report
+addId expressions =
+    return (unlines $ addIds expressions)
   where
     addIds = zipWith (\n s -> "p" ++ show n ++ " = " ++ s) [(1 :: Int)..]
 
@@ -29,13 +27,9 @@ toIntLog log = (intLog, Set.map a2i alphabet, i2a)
 main :: IO ()
 main = do
     options <- parseArgs
-    if (inputPath options == "") 
-        then putStrLn "Enter some traces: "
-        else do putStr ""
     let input = optInput options
-    let outPath = outputPath options 
-    let out = optOutput options
-    (logOriginal, alphabet, decode) <- fmap toIntLog $ readLog input
+    let output = optOutput options
+    !(logOriginal, alphabet, decode) <- fmap toIntLog $ readLog input
     let log    = if (optSplit options) then dropSubtraces $ split logOriginal else logOriginal
         oracle = oracleMokhovCarmona log
         events = Set.elems alphabet
@@ -43,15 +37,11 @@ main = do
                  Set.fromList [ (x, y) | x <- events, y <- events, x <= y ]
         co a b = cache Map.! (min a b, max a b)
         graphs = map (fmap decode) $ reduceLog co log 
-    let !concurrencyReport = [ (decode x, decode y) | (x:xs) <- tails events, y <- xs, x `co` y ]
-    
-    putStrLn "\nConcurrent pairs:"
-    print concurrencyReport
-    if (outPath == "") 
-        then
-          putStrLn "\nComplete. Results: "
-        else 
-          putStrLn $ "\nComplete. See results in '" ++ outPath ++ "'."
-    let [result] = addId (map printGraphExpr graphs)
-    out result
+    let [expressions] = addId (map printGraphExpr graphs)
+    if (optReport options) 
+        then do
+            let concurrenyReport = [ (decode x, decode y) | (x:xs) <- tails events, y <- xs, x `co` y ]
+            let result = expressions ++ "\nConcurrent pairs:" ++ show concurrenyReport
+            output result 
+        else output expressions 
     putStrLn ""

--- a/src/Tuura/CmdLineFlags.hs
+++ b/src/Tuura/CmdLineFlags.hs
@@ -1,29 +1,23 @@
 module Tuura.CmdLineFlags (Options(..), parseArgs, readLog
     ) where
 
-import Data.Set (Set)
-import qualified Data.Set as Set
 import Data.Foldable
 import System.Console.GetOpt
 import System.Environment
-import System.FilePath
-import Tuura.Concurrency
 import Tuura.Log
 
 data Options = Options
     { optSplit    :: Bool
     , optInput    :: IO String
     , optOutput   :: String -> IO ()
-    , inputPath   :: FilePath
-    , outputPath  :: FilePath
+    , optReport  :: Bool
     }
 
 defaultOptions    = Options
     { optSplit    = False
     , optInput    = getContents
     , optOutput   = putStr
-    , inputPath   = ""
-    , outputPath  = ""
+    , optReport  = False
     }
 
 options :: [OptDescr (Options -> IO Options)]
@@ -34,20 +28,23 @@ options =
         "Repeat events are set as separate as new events"
     , Option ['o']     ["output"]
         (ReqArg (\ f opts -> do
-                    return opts { optOutput = writeFile f, outputPath = f }) "FILE")
+                    return opts { optOutput = writeFile f}) "FILE")
         "Optional output .cpog file"
+    , Option ['c']     ["concurrency-report"]
+        (NoArg (\ opts -> do
+                   return opts { optReport = True }))
+        "Print a list of concurrent pairs"
     ]
 
 parseArgs :: IO Options
 parseArgs = do
   argv <- getArgs
   progName <- getProgName
-  let header = "Usage: " ++ progName ++ " <inputFilePath> [-s | --split] [-o | --output <outputFilePath>]"
+  let header = "Usage: \n" ++ progName ++ " <inputFilePath> [-s | --split] [-c | --concurrency-report] [-o | --output <outputFilePath>]"
   let helpMessage = usageInfo header options
   case getOpt Permute (options) argv of
     (opts, [], []) -> foldlM (flip id) defaultOptions opts
-    (opts, [input], []) -> foldlM (flip id) defaultOptions {optInput = readFile input
-                                                            , inputPath = input} opts
+    (opts, [input], []) -> foldlM (flip id) defaultOptions {optInput = readFile input} opts
     (opts, nonOpts, []) -> ioError (userError ("Only one input event log\n" ++ helpMessage))
     (_, _, errs) -> ioError (userError (concat errs))
 

--- a/src/Tuura/CmdLineFlags.hs
+++ b/src/Tuura/CmdLineFlags.hs
@@ -10,14 +10,14 @@ data Options = Options
     { optSplit    :: Bool
     , optInput    :: IO String
     , optOutput   :: String -> IO ()
-    , optReport  :: Bool
+    , optReport   :: Bool
     }
 
 defaultOptions    = Options
     { optSplit    = False
     , optInput    = getContents
     , optOutput   = putStr
-    , optReport  = False
+    , optReport   = False
     }
 
 options :: [OptDescr (Options -> IO Options)]


### PR DESCRIPTION
Simplified addID
Removed path fields
Included concurrency report command to output concurrent pairs only on request.
Added functionality to output partial orders and concurrency report to stdout by default, and to chosen file on request.
