### PR TITLE
Update stack.yaml for newer systems

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
 packages:
-- location: .
-resolver: lts-9.18
+- .
+resolver: lts-12.0


### PR DESCRIPTION
Hello,

I am compiling pgminer to work on RHEL8

I found that the stack.yaml would not allow me to build and needed to be updated.

`Aeson exception:`
`Error in $.packages[0]: failed to parse field 'packages': parsing Text failed, expected String, but encountered Object`

Tested on RHEL8, CentOS7 and Ubuntu 20.04

Regards
Paul